### PR TITLE
[Issue-14] make mFileDescSet and other private variables accessible via get methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 protobuf-dynamic release notes
 ==============================
 
+#### 1.0.1 (22-Apr-2020)
+* Make internal file descriptor of DynamicSchema accessible via get methods
+
 #### 1.0.0 (27-Nov-2018)
 * Oneof support (requires protobuf-java 2.6.1 or higher)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.github.os72</groupId>
   <artifactId>protobuf-dynamic</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>protobuf-dynamic</name>
   <url>https://github.com/os72/protobuf-dynamic</url>
   <description>Protocol Buffers Dynamic Schema</description>

--- a/src/main/java/com/github/os72/protobuf/dynamic/DynamicSchema.java
+++ b/src/main/java/com/github/os72/protobuf/dynamic/DynamicSchema.java
@@ -280,6 +280,26 @@ public class DynamicSchema
 	private Map<String,EnumDescriptor> mEnumDescriptorMapFull = new HashMap<String,EnumDescriptor>();
 	private Map<String,EnumDescriptor> mEnumDescriptorMapShort = new HashMap<String,EnumDescriptor>();
 
+	public FileDescriptorSet getmFileDescSet() {
+		return mFileDescSet;
+	}
+
+	public Map<String, Descriptor> getmMsgDescriptorMapFull() {
+		return mMsgDescriptorMapFull;
+	}
+
+	public Map<String, Descriptor> getmMsgDescriptorMapShort() {
+		return mMsgDescriptorMapShort;
+	}
+
+	public Map<String, EnumDescriptor> getmEnumDescriptorMapFull() {
+		return mEnumDescriptorMapFull;
+	}
+
+	public Map<String, EnumDescriptor> getmEnumDescriptorMapShort() {
+		return mEnumDescriptorMapShort;
+	}
+
 	/**
 	 * DynamicSchema.Builder
 	 */


### PR DESCRIPTION
This is required access so that we can use the mFileDescSet to convert proto schema into JSON using the method provided in proto3.